### PR TITLE
prevent error if default account store isn't mapped

### DIFF
--- a/stormpath_config/strategies/enrich_integration_from_remote_config.py
+++ b/stormpath_config/strategies/enrich_integration_from_remote_config.py
@@ -172,9 +172,11 @@ class EnrichIntegrationFromRemoteConfigStrategy(object):
             application = _resolve_application(client, config)
             config['application']['oAuthPolicy'] = _enrich_with_oauth_policy(application, config)
             social_config = _enrich_with_social_providers(application, config)
-            _extend_dict(config, social_config)
+            if social_config:
+                _extend_dict(config, social_config)
             directory = _resolve_directory(application)
             policy_config = _enrich_with_directory_policies(directory, config)
-            _extend_dict(config, policy_config)
+            if policy_config:
+                _extend_dict(config, policy_config)
 
         return config


### PR DESCRIPTION
Disabling default account store causes stormpath-python-config to fail.

  File "/home/cetko/projects/stormpath-python-config/stormpath_config/strategies/enrich_integration_from_remote_config.py", line 178, in process
    _extend_dict(config, policy_config)
  File "/home/cetko/projects/stormpath-python-config/stormpath_config/helpers.py", line 42, in _extend_dict
    for key, value in extend_with.items():
AttributeError: 'NoneType' object has no attribute 'items'
